### PR TITLE
Updated to use aref object and write-Warning

### DIFF
--- a/create.ps1
+++ b/create.ps1
@@ -16,19 +16,23 @@ $auditLogs = New-Object Collections.Generic.List[PSCustomObject];
 # Set TLS to accept TLS, TLS 1.1 and TLS 1.2
 [Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls -bor [Net.SecurityProtocolType]::Tls11 -bor [Net.SecurityProtocolType]::Tls12
 
-$personId = $p.externalId; # Profit Employee Medewerker
-$emailaddress = $p.Accounts.AzureADSchoulens.userPrincipalName;
-$userPrincipalName = $p.Accounts.AzureADSchoulens.userPrincipalName;
-# $telephoneNumber = $p.Accounts.AzureADSchoulens.telephoneNumber;
-# $mobile = $p.Accounts.AzureADSchoulens.mobile;
+$filterfieldid = "Persoonsnummer"
+$filtervalue = $p.externalId; # Has to match the AFAS value of the specified filter field ($filterfieldid)
+$emailaddress = $p.Accounts.MicrosoftActiveDirectory.mail;
+$userPrincipalName = $p.Accounts.MicrosoftActiveDirectory.userPrincipalName;
+# $telephoneNumber = $p.Accounts.MicrosoftActiveDirectory.telephoneNumber;
+# $mobile = $p.Accounts.MicrosoftActiveDirectory.mobile;
+
+$EmAdUpdated = $false
+$EmailPortalUpdated = $false
 
 try{
     $encodedToken = [System.Convert]::ToBase64String([System.Text.Encoding]::ASCII.GetBytes($Token))
     $authValue = "AfasToken $encodedToken"
     $Headers = @{ Authorization = $authValue }
-    $getUri = $BaseUri + "/connectors/" + $getConnector + "?filterfieldids=Persoonsnummer&filtervalues=$personId&operatortypes=1"
+    $getUri = $BaseUri + "/connectors/" + $getConnector + "?filterfieldids=$filterfieldid&filtervalues=$filtervalue&operatortypes=1"
     $getResponse = Invoke-RestMethod -Method Get -Uri $getUri -ContentType "application/json;charset=utf-8" -Headers $Headers -UseBasicParsing
-    
+
     if($getResponse.rows.Count -eq 1){
         # Retrieve current account data for properties to be updated
         $previousAccount = [PSCustomObject]@{
@@ -68,8 +72,8 @@ try{
                                     # Nummer
                                     'BcCo' = $getResponse.rows.Persoonsnummer;
 
-                                    # E-Mail toegang
-                                    'EmailPortal' = $userPrincipalName;
+                                    # E-Mail toegang - Check with AFAS Administrator if this needs to be set
+                                    # 'EmailPortal' = $userPrincipalName;
 
                                     <#
                                     # phone.business.fixed
@@ -84,15 +88,23 @@ try{
                 }
             }
         }
+        # Set variable to indicate update of EmailPortal has occurred (for export data object)
+        # $EmailPortalUpdated = $true
 
         # If '$emailAdddres' does not match current 'EmAd', add 'EmAd' to update body. AFAS will throw an error when trying to update this with the same value
-        if($getResponse.rows.Email_werk -ne $emailaddress){
+        if( $getResponse.rows.Email_werk -ne $emailaddress -and -not[string]::IsNullOrEmpty($emailaddress) ){
             # E-mail werk
             $account.'AfasEmployee'.'Element'.Objects[0].'KnPerson'.'Element'.'Fields' += @{'EmAd' = $emailaddress}
             Write-Verbose -Verbose "Updating BusinessEmailAddress '$($getResponse.rows.Email_werk)' with new value '$emailaddress'"
+            # Set variable to indicate update of EmAd has occurred (for export data object)
+            $EmAdUpdated = $true
         }   
 
-        $aRef = $($account.AfasEmployee.Values.'@EmId')
+        # Set aRef object for use in futher actions
+        $aRef = [PSCustomObject]@{
+            Medewerker = $getResponse.rows.Medewerker
+            Persoonsnummer = $getResponse.rows.Persoonsnummer
+        }
 
         if(-Not($dryRun -eq $True)){
             $body = $account | ConvertTo-Json -Depth 10
@@ -103,7 +115,7 @@ try{
 
         $auditLogs.Add([PSCustomObject]@{
             Action = "CreateAccount"
-            Message = "Correlated to and updated fields of account with id $aRef"
+            Message = "Correlated to and updated fields of account with id $($aRef.Medewerker)"
             IsError = $false;
         });
 
@@ -112,10 +124,10 @@ try{
 }catch{
     $auditLogs.Add([PSCustomObject]@{
         Action = "CreateAccount"
-        Message = "Error correlating and updating fields of account with Id $($aRef): $($_)"
+        Message = "Error correlating and updating fields of account with Id $($aRef.Medewerker): $($_)"
         IsError = $True
     });
-    Write-Error $_;
+    Write-Warning $_;
 }
 
 # Send results
@@ -128,9 +140,16 @@ $result = [PSCustomObject]@{
 
     # Optionally return data for use in other systems
     ExportData       = [PSCustomObject]@{
-        EmployeeId              = $($account.AfasEmployee.Values.'@EmId')
-        BusinessEmailAddress    = $($account.AfasEmployee.Element.Objects[0].KnPerson.Element.Fields.EmAd)
-        PortalEmailAddress      = $($account.AfasEmployee.Element.Objects[0].KnPerson.Element.Fields.EmailPortal)
+        Medewerker      = $aRef.Medewerker
+        Persoonsnummer  = $aRef.Persoonsnummer      
     };    
 };
+
+# Only add the data to ExportData if it has actually been updated, since we want to store the data HelloID has sent
+if($EmAdUpdated -eq $true){
+    $result.ExportData | Add-Member -MemberType NoteProperty -Name BusinessEmailAddress -Value $($account.AfasEmployee.Element.Objects[0].KnPerson.Element.Fields.EmAd) -Value "EmAd" -Force
+}
+if($EmailPortalUpdated -eq $true){
+    $result.ExportData | Add-Member -MemberType NoteProperty -Name PortalEmailAddress -Value $($account.AfasEmployee.Element.Objects[0].KnPerson.Element.Fields.EmailPortal) -Force
+}
 Write-Output $result | ConvertTo-Json -Depth 10;

--- a/delete.ps1
+++ b/delete.ps1
@@ -16,9 +16,10 @@ $auditLogs = New-Object Collections.Generic.List[PSCustomObject];
 # Set TLS to accept TLS, TLS 1.1 and TLS 1.2
 [Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls -bor [Net.SecurityProtocolType]::Tls11 -bor [Net.SecurityProtocolType]::Tls12
 
-$personId = $p.externalId; # Profit Employee Medewerker
-$emailaddress = "$personId@domain.com"; # Unique value based of PersonId because at the revoke action we want to clear the unique fields
-$userPrincipalName = "$personId@domain.com"; # Unique value based of PersonId because at the revoke action we want to clear the unique fields
+$filterfieldid = "Persoonsnummer"
+$filtervalue = $aRef.Persoonsnummer; # Has to match the AFAS value of the specified filter field ($filterfieldid)
+$emailaddress = "$($aRef.Persoonsnummer)@domain.com"; # Unique value based of PersonId because at the revoke action we want to clear the unique fields
+$userPrincipalName = "$($aRef.Persoonsnummer)@domain.com"; # Unique value based of PersonId because at the revoke action we want to clear the unique fields
 # $telephoneNumber = $p.Accounts.MicrosoftActiveDirectory.telephoneNumber;
 # $mobile = $p.Accounts.MicrosoftActiveDirectory.mobile;
 
@@ -26,9 +27,9 @@ try{
     $encodedToken = [System.Convert]::ToBase64String([System.Text.Encoding]::ASCII.GetBytes($Token))
     $authValue = "AfasToken $encodedToken"
     $Headers = @{ Authorization = $authValue }
-    $getUri = $BaseUri + "/connectors/" + $getConnector + "?filterfieldids=Persoonsnummer&filtervalues=$personId&operatortypes=1"
+    $getUri = $BaseUri + "/connectors/" + $getConnector + "?filterfieldids=$filterfieldid&filtervalues=$filtervalue&operatortypes=1"
     $getResponse = Invoke-RestMethod -Method Get -Uri $getUri -ContentType "application/json;charset=utf-8" -Headers $Headers -UseBasicParsing
-    
+
     if($getResponse.rows.Count -eq 1){
         # Retrieve current account data for properties to be updated
         $previousAccount = [PSCustomObject]@{
@@ -68,8 +69,8 @@ try{
                                     # Nummer
                                     'BcCo' = $getResponse.rows.Persoonsnummer;
 
-                                    # E-Mail toegang
-                                    'EmailPortal' = $userPrincipalName;
+                                    # E-Mail toegang - Check with AFAS Administrator if this needs to be set
+                                    # 'EmailPortal' = $userPrincipalName;
 
                                     <#
                                     # phone.business.fixed
@@ -83,15 +84,15 @@ try{
                     })
                 }
             }
-        }
+        }     
 
         # If '$emailAdddres' does not match current 'EmAd', add 'EmAd' to update body. AFAS will throw an error when trying to update this with the same value
-        if($getResponse.rows.Email_werk -ne $emailaddress){
+        if( $getResponse.rows.Email_werk -ne $emailaddress ){
             # E-mail werk
             $account.'AfasEmployee'.'Element'.Objects[0].'KnPerson'.'Element'.'Fields' += @{'EmAd' = $emailaddress}
             Write-Verbose -Verbose "Updating BusinessEmailAddress '$($getResponse.rows.Email_werk)' with new value '$emailaddress'"
         }   
-        
+
         if(-Not($dryRun -eq $True)){
             $body = $account | ConvertTo-Json -Depth 10
 
@@ -101,7 +102,7 @@ try{
 
         $auditLogs.Add([PSCustomObject]@{
             Action = "DeleteAccount"
-            Message = "Deleted link and updated fields of account with id $aRef"
+            Message = "Deleted link and updated fields of account with id $($aRef.Medewerker)"
             IsError = $false;
         });
 
@@ -110,10 +111,10 @@ try{
 }catch{
     $auditLogs.Add([PSCustomObject]@{
         Action = "DeleteAccount"
-        Message = "Error deleting link and updating fields of account with Id $($aRef): $($_)"
+        Message = "Error deleting link and updating fields of account with Id $($aRef.Medewerker): $($_)"
         IsError = $True
     });
-    Write-Error $_;
+    Write-Warning $_;
 }
 
 # Send results
@@ -122,13 +123,5 @@ $result = [PSCustomObject]@{
 	AccountReference= $aRef;
 	AuditLogs = $auditLogs;
     Account = $account;
-    PreviousAccount = $previousAccount;    
-
-    # Optionally return data for use in other systems
-    ExportData       = [PSCustomObject]@{
-        EmployeeId              = $($account.AfasEmployee.Values.'@EmId')
-        BusinessEmailAddress    = $($account.AfasEmployee.Element.Objects[0].KnPerson.Element.Fields.EmAd)
-        PortalEmailAddress      = $($account.AfasEmployee.Element.Objects[0].KnPerson.Element.Fields.EmailPortal)
-    };    
 };
 Write-Output $result | ConvertTo-Json -Depth 10;

--- a/update.ps1
+++ b/update.ps1
@@ -16,19 +16,23 @@ $auditLogs = New-Object Collections.Generic.List[PSCustomObject];
 # Set TLS to accept TLS, TLS 1.1 and TLS 1.2
 [Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls -bor [Net.SecurityProtocolType]::Tls11 -bor [Net.SecurityProtocolType]::Tls12
 
-$personId = $p.externalId; # Profit Employee Medewerker
-$emailaddress = $p.Accounts.AzureADSchoulens.userPrincipalName;
-$userPrincipalName = $p.Accounts.AzureADSchoulens.userPrincipalName;
-# $telephoneNumber = $p.Accounts.AzureADSchoulens.telephoneNumber;
-# $mobile = $p.Accounts.AzureADSchoulens.mobile;
+$filterfieldid = "Persoonsnummer"
+$filtervalue = $aRef.Persoonsnummer; # Has to match the AFAS value of the specified filter field ($filterfieldid)
+$emailaddress = $p.Accounts.MicrosoftActiveDirectory.mail;
+$userPrincipalName = $p.Accounts.MicrosoftActiveDirectory.userPrincipalName;
+# $telephoneNumber = $p.Accounts.MicrosoftActiveDirectory.telephoneNumber;
+# $mobile = $p.Accounts.MicrosoftActiveDirectory.mobile;
+
+$EmAdUpdated = $false
+$EmailPortalUpdated = $false
 
 try{
     $encodedToken = [System.Convert]::ToBase64String([System.Text.Encoding]::ASCII.GetBytes($Token))
     $authValue = "AfasToken $encodedToken"
     $Headers = @{ Authorization = $authValue }
-    $getUri = $BaseUri + "/connectors/" + $getConnector + "?filterfieldids=Persoonsnummer&filtervalues=$personId&operatortypes=1"
+    $getUri = $BaseUri + "/connectors/" + $getConnector + "?filterfieldids=$filterfieldid&filtervalues=$filtervalue&operatortypes=1"
     $getResponse = Invoke-RestMethod -Method Get -Uri $getUri -ContentType "application/json;charset=utf-8" -Headers $Headers -UseBasicParsing
-    
+
     if($getResponse.rows.Count -eq 1){
         # Retrieve current account data for properties to be updated
         $previousAccount = [PSCustomObject]@{
@@ -68,8 +72,8 @@ try{
                                     # Nummer
                                     'BcCo' = $getResponse.rows.Persoonsnummer;
 
-                                    # E-Mail toegang
-                                    'EmailPortal' = $userPrincipalName;
+                                    # E-Mail toegang - Check with AFAS Administrator if this needs to be set
+                                    # 'EmailPortal' = $userPrincipalName;
 
                                     <#
                                     # phone.business.fixed
@@ -84,13 +88,23 @@ try{
                 }
             }
         }
+        # Set variable to indicate update of EmailPortal has occurred (for export data object)
+        # $EmailPortalUpdated = $true
 
         # If '$emailAdddres' does not match current 'EmAd', add 'EmAd' to update body. AFAS will throw an error when trying to update this with the same value
-        if($getResponse.rows.Email_werk -ne $emailaddress){
+        if( $getResponse.rows.Email_werk -ne $emailaddress -and -not[string]::IsNullOrEmpty($emailaddress) ){
             # E-mail werk
             $account.'AfasEmployee'.'Element'.Objects[0].'KnPerson'.'Element'.'Fields' += @{'EmAd' = $emailaddress}
             Write-Verbose -Verbose "Updating BusinessEmailAddress '$($getResponse.rows.Email_werk)' with new value '$emailaddress'"
-        }   
+            # Set variable to indicate update of EmAd has occurred (for export data object)
+            $EmAdUpdated = $true
+        }
+
+        # Set aRef object for use in futher actions
+        $aRef = [PSCustomObject]@{
+            Medewerker = $getResponse.rows.Medewerker
+            Persoonsnummer = $getResponse.rows.Persoonsnummer
+        }        
         
         if(-Not($dryRun -eq $True)){
             $body = $account | ConvertTo-Json -Depth 10
@@ -101,7 +115,7 @@ try{
 
         $auditLogs.Add([PSCustomObject]@{
             Action = "UpdateAccount"
-            Message = "Updated fields of account with id $aRef"
+            Message = "Updated fields of account with id $($aRef.Medewerker)"
             IsError = $false;
         });
 
@@ -110,10 +124,10 @@ try{
 }catch{
     $auditLogs.Add([PSCustomObject]@{
         Action = "UpdateAccount"
-        Message = "Error updating fields of account with Id $($aRef): $($_)"
+        Message = "Error updating fields of account with Id $($aRef.Medewerker): $($_)"
         IsError = $True
     });
-	Write-Error $_;
+	Write-Warning $_;
 }
 
 # Send results
@@ -126,9 +140,16 @@ $result = [PSCustomObject]@{
 
     # Optionally return data for use in other systems
     ExportData       = [PSCustomObject]@{
-        EmployeeId              = $($account.AfasEmployee.Values.'@EmId')
-        BusinessEmailAddress    = $($account.AfasEmployee.Element.Objects[0].KnPerson.Element.Fields.EmAd)
-        PortalEmailAddress      = $($account.AfasEmployee.Element.Objects[0].KnPerson.Element.Fields.EmailPortal)
+        Medewerker      = $aRef.Medewerker
+        Persoonsnummer  = $aRef.Persoonsnummer      
     };    
 };
+
+# Only add the data to ExportData if it has actually been updated, since we want to store the data HelloID has sent
+if($EmAdUpdated -eq $true){
+    $result.ExportData | Add-Member -MemberType NoteProperty -Name BusinessEmailAddress -Value $($account.AfasEmployee.Element.Objects[0].KnPerson.Element.Fields.EmAd) -Value "EmAd" -Force
+}
+if($EmailPortalUpdated -eq $true){
+    $result.ExportData | Add-Member -MemberType NoteProperty -Name PortalEmailAddress -Value $($account.AfasEmployee.Element.Objects[0].KnPerson.Element.Fields.EmailPortal) -Force
+}
 Write-Output $result | ConvertTo-Json -Depth 10;


### PR DESCRIPTION
Updated to make use of the aRef object on every action where this is available (all actions except for the create action, since we create the aRef object in the create action.
This way the actions aren't dependent on data from other systems (source or target).

Also switched out the Write-Error for Write-Warning, since this can cause the audit log to not show the correct message.